### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ are copied verbatim alongside the Lambda function source files.)
 
 ## Makefile
 
-All actions are done through the Makefile. Just type `make` to see the help.
+All actions are done through the [Makefile](https://github.com/sportarchive/aws-lambda-python-local/blob/master/Makefile). Just type `make` to see the help.
 
 ### Creating
 


### PR DESCRIPTION
Add hyperlink to the provided Makefile

I initially thought that this project generates a Makefile for you. This
makes it clear that you have to use the project's Makefile.

Fixes #2.